### PR TITLE
feat(no-daily-time): displays max and min temp for daily

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
 
   const daily: Daily[] = data?.timelines?.daily?.map((item) => { 
     const time: string = item.time
-    const values: DailyValues = { temperatureMax: item.values.temperatureMax }
+    const values: DailyValues = { temperatureMax: item.values.temperatureMax, temperatureMin: item.values.temperatureMin }
     return {time, values}
   }) ?? []
 

--- a/src/WeatherData.tsx
+++ b/src/WeatherData.tsx
@@ -16,7 +16,7 @@ function WeatherData({ type, data }: WeatherDataProps) {
                     <div className="weather-item" key={item.time}>
                       <p>{date.slice(0, 4).join(' ')}</p>
                       <p>{type !== "Daily" ? date[4] : "Max temp: " + item.values.temperatureMax + " \u00B0C"}</p>
-                      <p>{"Temp: " + item.values.temperature ?? "Min temp: " + item.values.temperatureMin}{" \u00B0C"}</p>
+                      <p>{item.values.temperature ?? "Min temp: " + item.values.temperatureMin}{" \u00B0C"}</p>
                     </div>
                   )
                 })

--- a/src/WeatherData.tsx
+++ b/src/WeatherData.tsx
@@ -1,12 +1,13 @@
 import { WeatherDataProps } from "./types";
 
 function WeatherData({ type, data }: WeatherDataProps) {
+  const timezone: string | null = data && type !== "Daily" ? new Date(data[0].time).toString().split(' ').slice(6).join(' ') : null
   return (
     <>
       {
         data ? ( 
           <div className="forecast">
-            <h3>Your {type} Forecast {new Date(data[0].time).toString().split(' ').slice(6).join(' ')}</h3>
+            <h3>Your {type} Forecast {timezone}</h3>
             <div className="weather-grid">
               {
                 data.map((item) => {
@@ -14,8 +15,8 @@ function WeatherData({ type, data }: WeatherDataProps) {
                   return (
                     <div className="weather-item" key={item.time}>
                       <p>{date.slice(0, 4).join(' ')}</p>
-                      <p>{date[4]}</p>
-                      <p>{item.values.temperature ?? item.values.temperatureMax} Degrees Celcius</p>
+                      <p>{type !== "Daily" ? date[4] : "Max temp: " + item.values.temperatureMax + " \u00B0C"}</p>
+                      <p>{"Temp: " + item.values.temperature ?? "Min temp: " + item.values.temperatureMin}{" \u00B0C"}</p>
                     </div>
                   )
                 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export interface HourlyMinutely {
 
 export interface DailyValues {
   temperatureMax: number
+  temperatureMin: number
 }
 
 export interface Daily {


### PR DESCRIPTION
https://github.com/vsots/weather-app/issues/1

- Adds `temperatureMin` to `DailyValues` interface.
- Removes timezone and time for Daily weather.
- Displays `temperatureMax` and `temperatureMin` for Daily weather and adds `Max:` and `Min:` strings next to Daily temperatures.
- Edits `Degrees Celsius` string to `°C` string for all temperatures.